### PR TITLE
Added layers resource map with first layer for chrome-aws-lambda

### DIFF
--- a/services/layers/chromeAwsLambda/serverless.yml
+++ b/services/layers/chromeAwsLambda/serverless.yml
@@ -1,4 +1,4 @@
-service: chorme-aws-lambda-layer
+service: chrome-aws-lambda-layer
 
 provider:
   name: aws


### PR DESCRIPTION
## Explain the changes you’ve made

I have added a new component resource map for layers with an initial layer to store the chrome-aws-lambda lib.

## Explain why these changes are made

The new pdf service (pdf-ms) needs the chrome-aws-lambda lib in order to render html to pdf. The reason for putting this lib in a layer is due to that it's to big to package and deploy directly with the pdf-ms service. Without this lib we cannot generate pdf from html, since we need some sort of headless browser for the generation.

## Explain your solution

Creating a new layer that package the chrome-aws-lambda lib and exports the arn to be used elsewhere in other services.

## How to test the changes?

1. Checkout this branch
2. Deploy the layer in the chrome-aws-lambda directory
3. In your AWS console you should se a new stack created and that it's layer.

## Was this feature tested in the following environments?
- [X] Personal AWS environment.
