### PR TITLE
Feat/timeslots service

### DIFF
--- a/services/gateway/resources/timeslots/serverless.yml
+++ b/services/gateway/resources/timeslots/serverless.yml
@@ -1,0 +1,30 @@
+service: timeslots-gateway-resource
+
+custom: ${file(../../../../serverless.common.yml):custom}
+
+provider:
+  name: aws
+  runtime: nodejs12.x
+  stage: dev
+  region: eu-north-1
+
+  apiGateway:
+    restApiId:
+      !ImportValue ${self:custom.stage}-ExtApiGatewayRestApiId
+    restApiRootResourceId:
+      !ImportValue ${self:custom.stage}-ExtApiGatewayRestApiRootResourceId
+
+resources:
+  Resources:
+    ApiGatewayResourceTimeSlots:
+      Type: AWS::ApiGateway::Resource
+      Properties:
+        RestApiId: ${self:provider.apiGateway.restApiId}
+        ParentId: ${self:provider.apiGateway.restApiRootResourceId}
+        PathPart: timeslots
+
+  Outputs:
+    ApiGatewayResourceTimeSlots:
+      Value: !Ref ApiGatewayResourceTimeSlots
+      Export:
+        Name: ${self:custom.stage}-ExtApiGatewayResourceTimeSlots

--- a/services/parameterStore/envs/example.timeSlotsEnvs.json
+++ b/services/parameterStore/envs/example.timeSlotsEnvs.json
@@ -1,0 +1,4 @@
+{
+    "outlookTimeSlotsEndpoint": "datatorget_outlook_timeslots_endpoint",
+    "apiKey": "datatorget_api_key"
+}


### PR DESCRIPTION
## What was solved
Adding "timeslots" as a new API Gateway resource path which should be used when using the timeslots-api service.

## How was it solved
Created a new serverless stack called timeslots-gateway-resource which creates the new api gateway resource and adds it to the root api gateway.

## Why was it solved in this way
This is the agreed way of creating Api Gateway resources for the root Api Gateway.

## How was it tested
Tested by first deploying the root Api Gateway (gateway-root) serverless stack. Checked the Api Gateway console and verified that the new resource was attached to the root gateway.